### PR TITLE
Makes the workshop project agnostic, by forcing the user to input the project-id

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,7 @@
+# top-most EditorConfig file
+root = true
+
+[*]
 tab_width = 2
 charset = utf-8
 end_of_line = lf

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Abrir o editor na pasta do projeto:
 E agora que têm o editor pronto, podemos autenticar a consola com o GCP:
 
 ```bash
-gcloud config set project tf-gke-lab-01-np-000001
+gcloud config set project <project-id>
 ```
 
 Para iniciar o tutorial, executamos o seguinte comando na consola:
@@ -113,7 +113,7 @@ gcloud init
 gcloud auth application-default login
 
 # definir o projeto por defeito (opcional)
-gcloud config set project tf-gke-lab-01-np-000001
+gcloud config set project <project-id>
 ```
 
 Por fim, podemos clonar o projeto:
@@ -135,10 +135,10 @@ gcloud compute regions list
 gcloud compute zones list | grep europe-west1
 
 # listar VMs para um dado projecto
-gcloud compute instances list --project tf-gke-lab-01-np-000001
+gcloud compute instances list --project <project-id>
 
 # ligar à VM usando o IAP
-gcloud compute ssh <vm-name> --project=tf-gke-lab-01-np-000001 --zone europe-west1-b
+gcloud compute ssh <vm-name> --project=<project-id>1 --zone europe-west1-b
 
 # obter o self-link de uma vpc a importar do lado do GCP
 gcloud compute networks list --uri | grep "$(terraform output -raw my_identifier)"

--- a/bootstrap/iam.tf
+++ b/bootstrap/iam.tf
@@ -1,0 +1,35 @@
+# iam
+locals {
+
+  iam_members = [
+    {
+      member = "group:${var.gcp_trainer_group}"
+      roles = [
+        "roles/editor",
+        "roles/iap.tunnelResourceAccessor",
+        "roles/container.admin"
+      ]
+    }
+  ]
+
+  iam_members_flattened = flatten([
+    for key, item in local.iam_members : [
+      for role_key, role in item.roles : {
+        member = item.member
+        role   = role
+      }
+    ]
+  ])
+}
+
+resource "google_project_iam_member" "this" {
+  for_each = { for iam_member in local.iam_members_flattened : "${iam_member.role}|${iam_member.member}" => iam_member }
+  project  = data.google_project.this.name
+  role     = each.value.role
+  member   = each.value.member
+
+  #Cloud Build creates the SA after enabling the API, so we need it to be enabled first
+  depends_on = [
+    google_project_service.this
+  ]
+}

--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -1,0 +1,45 @@
+## terraform & providers
+terraform {
+  required_version = ">= 1.0.0"
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4"
+    }
+  }
+}
+
+provider "google" {
+  # Configuration options
+  project = var.project_id
+  region  = var.region
+}
+
+data "google_project" "this" {
+  project_id = var.project_id
+}
+
+# services
+
+## Enable services
+locals {
+  gcp_service_list = [
+    "compute.googleapis.com",
+    "container.googleapis.com",
+    "dns.googleapis.com",
+    "serviceusage.googleapis.com"
+  ]
+}
+
+resource "google_project_service" "this" {
+  for_each = toset(local.gcp_service_list)
+  project  = data.google_project.this.project_id
+
+  service                    = each.key
+  disable_dependent_services = true
+  disable_on_destroy         = true
+}

--- a/bootstrap/resources.tf
+++ b/bootstrap/resources.tf
@@ -1,0 +1,29 @@
+# resources
+resource "google_compute_network" "default" {
+  name                    = "vpc-default"
+  auto_create_subnetworks = false
+
+  depends_on = [
+    google_project_iam_member.this
+  ]
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "subnetwork-default"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = var.region
+  network       = google_compute_network.default.id
+}
+
+resource "google_compute_firewall" "default" {
+  name     = "fw-ingressfromiap-p-01"
+  network  = google_compute_network.default.name
+  priority = 1000
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_tags = ["allow-iap"]
+}

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -1,0 +1,15 @@
+variable "project_id" {
+  description = "The project id to bootstrap resources."
+  type        = string
+}
+
+variable "region" {
+  description = "The default region to create resources."
+  type        = string
+  default     = "europe-west1"
+}
+
+variable "gcp_trainer_group" {
+  description = "The group of the trainers for IAM purposes."
+  type        = string
+}

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.74.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,2 +1,2 @@
-project_id = ""
+#project_id = ""
 prefix = "gcp"

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,2 +1,2 @@
-project_id = "tf-gke-lab-01-np-000001"
-prefix = "nos"
+project_id = ""
+prefix = "gcp"

--- a/tutorial.md
+++ b/tutorial.md
@@ -15,25 +15,16 @@
 
 **Pré requsitos**: Antes de começares, é necessário verificares algumas coisas:
 
-Junta-te à **Cloud Guild** no Teams e segue os tutorias da Wiki do GCP.
-
-Depois pede para te adicionarem ao projeto no GCP.
-
-De seguida vais ter de configurar o GCP. Se já tens o `gcloud` instalado corre este comando:
-
-**NOTA: Se estás a executar tutorial na cloudshell (consola do GCP), não precisas de correr este comando.**
-
-```bash
-gcloud auth application-default login
-```
-
-Podes econtrar mais info sobre a auth [aqui](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/getting_started).
-
 Certifica-te que tens a `google-cloud-shell` devidamente autorizada correndo este comando:
 
 ```bash
 gcloud config set project <project-id>
 ```
+
+Para evitar que o terraform peça o nome do projeto a cada `apply`, podemos definir o nome do projeto por defeito:
+
+* Abrir o ficheiro `terraform.tfvars`
+* Descomentar a linha `project_id` e adicionar o id do projeto.
 
 De seguida, clica no botão **Start** para começares.
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -32,7 +32,7 @@ Podes econtrar mais info sobre a auth [aqui](https://registry.terraform.io/provi
 Certifica-te que tens a `google-cloud-shell` devidamente autorizada correndo este comando:
 
 ```bash
-gcloud config set project tf-gke-lab-01-np-000001
+gcloud config set project <project-id>
 ```
 
 De seguida, clica no botão **Start** para começares.
@@ -72,7 +72,7 @@ terraform apply plan.tfplan
 verificar que o recurso remoto foi criado:
 
 ```bash
-gcloud compute instances list --project tf-gke-lab-01-np-000001
+gcloud compute instances list
 ```
 
 ### Comando `destroy`
@@ -88,7 +88,7 @@ terraform destroy
 verificar que o recurso remoto foi destruido:
 
 ```bash
-gcloud compute instances list --project tf-gke-lab-01-np-000001
+gcloud compute instances list
 ```
 
 ## 2. lidar com as alterações
@@ -168,7 +168,7 @@ gcloud compute ssh $(terraform output -raw vm_name) --project=$(terraform output
 
 > **As alterações também podem ser derivadas de dependêndencias, e quando isso acontece, todo o grafo de dependendencias é afetado.**
 
-* Editar o ficheiro `terraform.tfvars` e alterar o valor da variavel `prefix` de `nos` para `woo`
+* Editar o ficheiro `terraform.tfvars` e alterar o valor da variavel `prefix` de `gcp` para `new`
 
 Executar o `plan` e verificar todo o grafo de dependencias é afetado:
 

--- a/variables.tf
+++ b/variables.tf
@@ -12,5 +12,5 @@ variable "region" {
 variable "prefix" {
   type        = string
   description = "A simple prefix"
-  default     = "nos"
+  default     = "gcp"
 }


### PR DESCRIPTION
# 📑 Description

Makes the workshop project agnostic, by forcing the user to input the project-id

Also, the following were added:
* Removed every NOS or project occurrence
* Added a `bootstrap` terraform project to bootstrap projects with the minimum required permissions