### PR TITLE
Add log config to created subnets

### DIFF
--- a/import-exercise.tf
+++ b/import-exercise.tf
@@ -11,6 +11,13 @@
 #  region        = var.region
 #  ip_cidr_range = "10.0.0.0/9"
 #  network       = google_compute_network.imported.id
+#
+#  log_config { # This is required due to an organization policy
+#    aggregation_interval = "INTERVAL_10_MIN"
+#    flow_sampling        = 0.3
+#    metadata             = "EXCLUDE_ALL_METADATA"
+#  }
+#
 #}
 
 ## 3.3 Descomentar apenas quando for pedido


### PR DESCRIPTION
# 📑 Description

This PR does:

- Add subnet log config to the created subnets due to the organization policy created here: https://github.com/nosportugal/terraform-gcp-secops-p/pull/216